### PR TITLE
I changed the code a little bit. Now responds to robot too.

### DIFF
--- a/cvc/cozmo_voice_commands.py
+++ b/cvc/cozmo_voice_commands.py
@@ -32,7 +32,6 @@ log = False
 wait_for_shift = True
 lang = None
 lang_data = None
-commands_activate = ["cozmo", "cosmo", "cosimo", "cosma", "cosima", "kosmos", "cosmos", "cosmic", "osmo", "kosovo", "peau", "kosmo", "kozmo", "gizmo"]
 vc = None
 languages = []
 


### PR DESCRIPTION
When recognized with a forward command it says:
- You said: robot forward
Action command recognized: {'robot'}
Cozmo drives forward for X seconds.

when not recognized it says:
- You did not say the magic word:   Cozmo
or robot