### PR TITLE
correction for french separator and forward

### DIFF
--- a/cvc/languages/fr.json
+++ b/cvc/languages/fr.json
@@ -3,15 +3,15 @@
     "name":"French",
     "lang":"fr",
     "lang_ext":"fr-FR",
-    "separator":"alors",
-    "instructions":"Donnez une commande vocale à Cozmo. Vous pouvez en donner plusieurs en les séparant par le mot 'ALORS'.\nI Les commandes disponibles sont:",
+    "separator":"puis",
+    "instructions":"Donnez une commande vocale à Cozmo. Vous pouvez en donner plusieurs en les séparant par le mot 'PUIS'.\nI Les commandes disponibles sont:",
     "text_wait":"\nAPPUYEZ SUR <SHIFT> LORSQUE VOUS ÊTES PRÊT À PARLER...",
     "text_say":"\nDites vos commandes (Tiemout: 5 secondes - ctrl+c pour quitter)",
     "error_one":"Je suis désolé, je n'ai pas compris toutes les commandes, les commandes disponibles sont:",
     "error_all":"Je suis désolé, je n'ai compris aucune de vos commandes, les commandes disponibles sont:",
     "commands":
     [
-        {"action":"forward", "words":["avance","recule"], "usage":"Cozmo avance pendant X secondes."},
+        {"action":"forward", "words":["avance"], "usage":"Cozmo avance pendant X secondes."},
         {"action":"backward", "words":["recule"], "usage":"Cozmo recule pendant X secondes."},
         {"action":"right", "words":["droit"], "usage":"Cozmo tourne à droit de X degrés."},
         {"action":"left", "words":["gauche"], "usage":"Cozmo tourne à gauche de X degrés."},


### PR DESCRIPTION
A better instruction separator in french would be "puis" and I also removed "recule" from the french forward command.